### PR TITLE
Fix URL in pthread.cabal

### DIFF
--- a/pthread.cabal
+++ b/pthread.cabal
@@ -1,7 +1,7 @@
 name:                pthread
 version:             0.1
 synopsis:            Bindings for the pthread library.
-homepage:            http://github.com/tweag/pthreads
+homepage:            http://github.com/tweag/pthread
 license:             BSD3
 license-file:        LICENSE
 author:              Tweag I/O
@@ -17,7 +17,7 @@ extra-source-files:
 
 source-repository head
   type:     git
-  location: https://github.com/tweag/pthreads
+  location: https://github.com/tweag/pthread
 
 library
   hs-source-dirs: src


### PR DESCRIPTION
Previously it was pointing to the non-existent URL https://github.com/tweag/pthreads.