### PR TITLE
Add needed Semigroup instance

### DIFF
--- a/pthread.cabal
+++ b/pthread.cabal
@@ -25,7 +25,7 @@ library
   exposed-modules:
     System.Posix.Thread
   build-depends:
-    base > 4.9.0.0 && < 5,
+    base >= 4.11.0.0 && < 5,
     generic-deriving >= 1.11
   default-language: Haskell2010
 

--- a/src/System/Posix/Thread.hsc
+++ b/src/System/Posix/Thread.hsc
@@ -225,9 +225,11 @@ data AttributesMonoid = AttributesMonoid
   , stackSize :: First CSize
   } deriving (Generic, Show)
 
+instance Semigroup AttributesMonoid where
+  (<>) = mappenddefault
+
 instance Monoid AttributesMonoid where
   mempty = memptydefault
-  mappend = mappenddefault
 
 monoidFromAttributes :: Attributes -> AttributesMonoid
 monoidFromAttributes Attributes{..} =


### PR DESCRIPTION
Necessary for newer base. This drops backwards compatibility.